### PR TITLE
path filter's should return "/" if given <front>

### DIFF
--- a/dist/_twig-components/functions/path.function.php
+++ b/dist/_twig-components/functions/path.function.php
@@ -1,5 +1,9 @@
 <?php
 
 $function = new Twig_SimpleFunction('path', function ($string) {
-  return $string;
+  if ($string === '<front>') {
+    return '/';
+  } else {
+    return $string;
+  }
 });


### PR DESCRIPTION
Homepage Drupal arg is `<front>` and should get back `/`. I realize this won't always go to the homepage in a Pattern Lab site, but I figured it was better than having `<a href="<front>">Home</a>`. Thoughts of stuff besides `/`?