### PR TITLE
link function attributes

### DIFF
--- a/dist/_twig-components/functions/link.function.php
+++ b/dist/_twig-components/functions/link.function.php
@@ -2,8 +2,13 @@
 
 $function = new Twig_SimpleFunction(
     'link',
-    function ($title, $url) {
+    function ($title, $url, $attributes) {
+      if (isset($attributes) && isset($attributes['class'])) {
+        $classes = join(' ', $attributes['class']);
+        return '<a href="' . $url . '" class="' . $classes . '">' . $title . '</a>';
+      } else {
         return '<a href="' . $url . '">' . $title . '</a>';
+      }
     },
     array('is_safe' => array('html'))
 );


### PR DESCRIPTION
This gives the `{{ link() }}` Twig function a third argument for attributes. It could be expanded to use Aleski's `plugin-data-transform`'s `Attribute()`, but I figured it'd be mainly useful for adding classes. This lets us do this:

    {{ link(item.title, item.url, { 'class':['nav-link']}) }}

[Drupal docs](https://www.drupal.org/node/2486991) on this.
