### PR TITLE
Add pattern scaffolding css

### DIFF
--- a/dist/_meta/_00-head.twig
+++ b/dist/_meta/_00-head.twig
@@ -4,13 +4,14 @@
 		<title>{{ title }}</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width" />
-		
+
 		<link rel="stylesheet" href="../../css/style.css?{{ cacheBuster }}" media="all" />
-		
+		<link rel="stylesheet" href="../../css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />
+
 		<!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
 		{{ patternLabHead | raw }}
 		<!-- End Pattern Lab -->
-		
+
 	</head>
 	<body class="{{ bodyClass }}">
-	
+

--- a/dist/css/pattern-scaffolding.css
+++ b/dist/css/pattern-scaffolding.css
@@ -1,0 +1,54 @@
+/**
+ * This stylesheet is for styles you want to include only when displaying demo
+ * styles for grids, animations, color swatches, etc.
+ * These styles will not be your production CSS.
+ */
+#sg-patterns {
+  -webkit-box-sizing: border-box !important;
+          box-sizing: border-box !important;
+  max-width: 100%;
+  padding: 0 0.5em;
+}
+
+.demo-animate {
+  background: #ddd;
+  padding: 1em;
+  margin-bottom: 1em;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.sg-colors {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.sg-colors li {
+  -webkit-box-flex: 1;
+      -ms-flex: auto;
+          flex: auto;
+  padding: 0.3em;
+  margin: 0 0.5em 0.5em 0;
+  min-width: 5em;
+  max-width: 14em;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.sg-swatch {
+  display: block;
+  height: 4em;
+  margin-bottom: 0.3em;
+  border-radius: 5px;
+}
+
+.sg-label {
+  font-size: 90%;
+  line-height: 1;
+}


### PR DESCRIPTION
The CSS in the pattern scaffolding seems appropriate even in a minimal starterkit, since (1) it is a good example of how to include css that doesn't have to be included in the final project (Drupal in the case of this starterkit) and (2) it provides basic styles that correspond to the basic atoms that are included (eg. color swatches).

This is pattern currently being followed done in the twig demo starterkit.